### PR TITLE
Wait should not raise exceptions

### DIFF
--- a/http_calls.py
+++ b/http_calls.py
@@ -213,10 +213,7 @@ class RestTools(HttpCall):
                 return False
 
         result = self.wait(wait_sec, retries, func, attr=attr, url=url)
-        if result is False:
-            raise Exception('Actual value: %s' % self.getAttributeFromResponse(attr, url))
-
-        return result
+        return result 
 
     def waitSecondTimesUrlResponseAttributeNotZero(self, wait_sec, retries, url, attr):
         def func(args):

--- a/tests/RestApiSuite/TestWaitAttribute/content.txt
+++ b/tests/RestApiSuite/TestWaitAttribute/content.txt
@@ -3,7 +3,7 @@
 |Carmela  |Soprano     |
 
 -!|script|RestTools|
-|wait|0.2|second|2|times url|${URL}/users/1|response attribute|FirstName|has value|Carmela|
+|show|wait|0.2|second|2|times url|${URL}/users/1|response attribute|FirstName|has value|Carmela|
 
 !|put|${URL}/change/user|
 |id  |FirstName|LastName|
@@ -11,3 +11,7 @@
 
 -!|script|RestTools|
 |wait|0.2|second|25|times url|${URL}/users/1|response attribute|FirstName|has value|Tony|
+
+|query:last response as table|
+|body.FirstName              |
+|Tony                        |


### PR DESCRIPTION
Now it makes tests yellow - not red. 
With this PR, the value is not being shown by `wait` but it can easily be checked by `query:last response as table` fixture

![image](https://cloud.githubusercontent.com/assets/405005/19902765/0fbc808a-a07d-11e6-81f8-cb7eb43585b9.png)
